### PR TITLE
Fix terraform migrations script to reconfigure otherwise is duplication

### DIFF
--- a/internal/tools/terraform/plan.go
+++ b/internal/tools/terraform/plan.go
@@ -26,6 +26,7 @@ func (c *Cmd) Init(remoteKey string) error {
 		Arg("backend-config", fmt.Sprintf("bucket=%s", c.remoteStateBucket)),
 		Arg("backend-config", fmt.Sprintf("key=%s/%s", remoteStateDirectory, remoteKey)),
 		Arg("backend-config", fmt.Sprintf("region=%s", os.Getenv("AWS_REGION"))),
+		Arg("reconfigure"),
 	)
 	if err != nil {
 		return errors.Wrap(err, "failed to invoke terraform init")

--- a/terraform/aws/customer-migrations/version.tf
+++ b/terraform/aws/customer-migrations/version.tf
@@ -1,5 +1,8 @@
 terraform {
   required_version = "~> 1.1.7"
+  backend "s3" {
+    region = "us-east-1"
+  }
   required_providers {
     aws = "~> 4.8.0"
   }


### PR DESCRIPTION
#### Summary
We are following the same practice as we do in other similar cases to reconfigure the terraform
backend in order to avoid the duplication from the terraform state under the S3 path.

#### Release Note

```release-note
Fix terraform migrations script
```
